### PR TITLE
Remove custom setuptools

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-11
   strategy:
     matrix:
       osx_64_python3.10.____cpython:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About docutils
 
 Home: http://docutils.sourceforge.net/
 
-Package license: Public Domain Dedictation and BSD 2-Clause and PSF 2.1.1 and GPL 3.0
+Package license: LicenseRef-Public-Domain-Dedictation and BSD 2-Clause and PSF 2.1.1 and GPL 3.0
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/docutils-feedstock/blob/master/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools =57.4
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,25 +7,17 @@ package:
 source:
   - url: https://pypi.io/packages/source/d/docutils/docutils-{{ version }}.tar.gz
     sha256: a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99
-  - url: https://pypi.io/packages/source/s/setuptools/setuptools-57.4.0.tar.gz
-    sha256: 6bac238ffdf24e8806c61440e755192470352850f3419a52f26ffe0a1a64f465
-    folder: setuptools-src
-
 
 build:
   number: 5
   script:
-    - "{{ PYTHON }} -m pip uninstall -y setuptools"
-    - "cd setuptools-src"
-    - "{{ PYTHON }} -m pip install ."
-    - "cd .."
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
-    - "{{ PYTHON }} -m pip uninstall -y setuptools"
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - setuptools =57.4
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,14 @@ source:
 
 
 build:
-  number: 4
+  number: 5
   script:
     - "{{ PYTHON }} -m pip uninstall -y setuptools"
     - "cd setuptools-src"
     - "{{ PYTHON }} -m pip install ."
     - "cd .."
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
+    - "{{ PYTHON }} -m pip uninstall -y setuptools"
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #43 to remove the new version of setuptools after building the package, to avoid packaging this setuptools into the package.
See https://github.com/conda-forge/artifact-validation/issues/897#issuecomment-1206485235
<!--
Please add any other relevant info below:
-->
